### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         run: pre-commit run --color=always --show-diff-on-failure --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ module "user_queue" {
 |------|---------|
 | aws | >= 2.30 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/2.30/docs/data-sources/arn) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/2.30/docs/resources/sqs_queue) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -88,7 +99,6 @@ module "user_queue" {
 | this\_sqs\_queue\_arn | The ARN of the SQS queue |
 | this\_sqs\_queue\_id | The URL for the created Amazon SQS queue |
 | this\_sqs\_queue\_name | The name of the SQS queue |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,6 +28,19 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.30 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| users_encrypted | ../../ |  |
+| users_unencrypted | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/2.30/docs/resources/kms_key) |
+
 ## Inputs
 
 No input.
@@ -40,5 +53,4 @@ No input.
 | users\_encrypted\_this\_sqs\_queue\_id | The URL for the created Amazon SQS queue |
 | users\_unencrypted\_this\_sqs\_queue\_arn | The ARN of the SQS queue |
 | users\_unencrypted\_this\_sqs\_queue\_id | The URL for the created Amazon SQS queue |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
