### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -52,53 +52,53 @@ module "user_queue" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
-| aws | >= 2.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.30 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) |
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) |
+| Name | Type |
+|------|------|
+| [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_arn.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| content\_based\_deduplication | Enables content-based deduplication for FIFO queues | `bool` | `false` | no |
-| create | Whether to create SQS queue | `bool` | `true` | no |
-| delay\_seconds | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes) | `number` | `0` | no |
-| fifo\_queue | Boolean designating a FIFO queue | `bool` | `false` | no |
-| kms\_data\_key\_reuse\_period\_seconds | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours) | `number` | `300` | no |
-| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
-| max\_message\_size | The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB) | `number` | `262144` | no |
-| message\_retention\_seconds | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days) | `number` | `345600` | no |
-| name | This is the human-readable name of the queue. If omitted, Terraform will assign a random name. | `string` | `null` | no |
-| name\_prefix | A unique name beginning with the specified prefix. | `string` | `null` | no |
-| policy | The JSON policy for the SQS queue | `string` | `""` | no |
-| receive\_wait\_time\_seconds | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds) | `number` | `0` | no |
-| redrive\_policy | The JSON policy to set up the Dead Letter Queue, see AWS docs. Note: when specifying maxReceiveCount, you must specify it as an integer (5), and not a string ("5") | `string` | `""` | no |
-| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| visibility\_timeout\_seconds | The visibility timeout for the queue. An integer from 0 to 43200 (12 hours) | `number` | `30` | no |
+| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Enables content-based deduplication for FIFO queues | `bool` | `false` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create SQS queue | `bool` | `true` | no |
+| <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds) | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes) | `number` | `0` | no |
+| <a name="input_fifo_queue"></a> [fifo\_queue](#input\_fifo\_queue) | Boolean designating a FIFO queue | `bool` | `false` | no |
+| <a name="input_kms_data_key_reuse_period_seconds"></a> [kms\_data\_key\_reuse\_period\_seconds](#input\_kms\_data\_key\_reuse\_period\_seconds) | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours) | `number` | `300` | no |
+| <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
+| <a name="input_max_message_size"></a> [max\_message\_size](#input\_max\_message\_size) | The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB) | `number` | `262144` | no |
+| <a name="input_message_retention_seconds"></a> [message\_retention\_seconds](#input\_message\_retention\_seconds) | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days) | `number` | `345600` | no |
+| <a name="input_name"></a> [name](#input\_name) | This is the human-readable name of the queue. If omitted, Terraform will assign a random name. | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A unique name beginning with the specified prefix. | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | The JSON policy for the SQS queue | `string` | `""` | no |
+| <a name="input_receive_wait_time_seconds"></a> [receive\_wait\_time\_seconds](#input\_receive\_wait\_time\_seconds) | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds) | `number` | `0` | no |
+| <a name="input_redrive_policy"></a> [redrive\_policy](#input\_redrive\_policy) | The JSON policy to set up the Dead Letter Queue, see AWS docs. Note: when specifying maxReceiveCount, you must specify it as an integer (5), and not a string ("5") | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_visibility_timeout_seconds"></a> [visibility\_timeout\_seconds](#input\_visibility\_timeout\_seconds) | The visibility timeout for the queue. An integer from 0 to 43200 (12 hours) | `number` | `30` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_sqs\_queue\_arn | The ARN of the SQS queue |
-| this\_sqs\_queue\_id | The URL for the created Amazon SQS queue |
-| this\_sqs\_queue\_name | The name of the SQS queue |
+| <a name="output_this_sqs_queue_arn"></a> [this\_sqs\_queue\_arn](#output\_this\_sqs\_queue\_arn) | The ARN of the SQS queue |
+| <a name="output_this_sqs_queue_id"></a> [this\_sqs\_queue\_id](#output\_this\_sqs\_queue\_id) | The URL for the created Amazon SQS queue |
+| <a name="output_this_sqs_queue_name"></a> [this\_sqs\_queue\_name](#output\_this\_sqs\_queue\_name) | The name of the SQS queue |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,38 +19,38 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
-| aws | >= 2.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.30 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| users_encrypted | ../../ |  |
-| users_unencrypted | ../../ |  |
+| <a name="module_users_encrypted"></a> [users\_encrypted](#module\_users\_encrypted) | ../../ |  |
+| <a name="module_users_unencrypted"></a> [users\_unencrypted](#module\_users\_unencrypted) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
+| Name | Type |
+|------|------|
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| users\_encrypted\_this\_sqs\_queue\_arn | The ARN of the SQS queue |
-| users\_encrypted\_this\_sqs\_queue\_id | The URL for the created Amazon SQS queue |
-| users\_unencrypted\_this\_sqs\_queue\_arn | The ARN of the SQS queue |
-| users\_unencrypted\_this\_sqs\_queue\_id | The URL for the created Amazon SQS queue |
+| <a name="output_users_encrypted_this_sqs_queue_arn"></a> [users\_encrypted\_this\_sqs\_queue\_arn](#output\_users\_encrypted\_this\_sqs\_queue\_arn) | The ARN of the SQS queue |
+| <a name="output_users_encrypted_this_sqs_queue_id"></a> [users\_encrypted\_this\_sqs\_queue\_id](#output\_users\_encrypted\_this\_sqs\_queue\_id) | The URL for the created Amazon SQS queue |
+| <a name="output_users_unencrypted_this_sqs_queue_arn"></a> [users\_unencrypted\_this\_sqs\_queue\_arn](#output\_users\_unencrypted\_this\_sqs\_queue\_arn) | The ARN of the SQS queue |
+| <a name="output_users_unencrypted_this_sqs_queue_id"></a> [users\_unencrypted\_this\_sqs\_queue\_id](#output\_users\_unencrypted\_this\_sqs\_queue\_id) | The URL for the created Amazon SQS queue |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
