### PR TITLE
fix: Extend example with custom policy

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,6 +40,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Type |
 |------|------|
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_sqs_queue_policy.users_unencrypted_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,3 +25,27 @@ module "users_encrypted" {
     Secure = "true"
   }
 }
+
+resource "aws_sqs_queue_policy" "users_unencrypted_policy" {
+  queue_url = module.users_unencrypted.sqs_queue_id
+
+  policy = <<EOF
+  {
+    "Version": "2008-10-17",
+    "Id": " policy",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::myaccount:root"
+        },
+        "Action": [
+          "SQS:SendMessage",
+          "SQS:ReceiveMessage"
+        ],
+        "Resource": "${module.users_unencrypted.sqs_queue_arn}"
+      }
+    ]
+  }
+  EOF
+}


### PR DESCRIPTION
## Description
Provides an example on how to add a policy to the queue.

## Motivation and Context
Provides an example on how to add a policy to the queue.

Fixes #7

## Breaking Changes
Not a breaking change.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

terraform init
terraform plan
terraform apply