### PR TITLE
feat: Added support for `deduplication_scope` and `fifo_throughput_limit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ module "user_queue" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63 |
 
 ## Modules
 
@@ -68,8 +68,10 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Enables content-based deduplication for FIFO queues | `bool` | `false` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create SQS queue | `bool` | `true` | no |
+| <a name="input_deduplication_scope"></a> [deduplication\_scope](#input\_deduplication\_scope) | Specifies whether message deduplication occurs at the message group or queue level | `string` | `null` | no |
 | <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds) | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes) | `number` | `0` | no |
 | <a name="input_fifo_queue"></a> [fifo\_queue](#input\_fifo\_queue) | Boolean designating a FIFO queue | `bool` | `false` | no |
+| <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input\_fifo\_throughput\_limit) | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group | `string` | `null` | no |
 | <a name="input_kms_data_key_reuse_period_seconds"></a> [kms\_data\_key\_reuse\_period\_seconds](#input\_kms\_data\_key\_reuse\_period\_seconds) | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours) | `number` | `300` | no |
 | <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
 | <a name="input_max_message_size"></a> [max\_message\_size](#input\_max\_message\_size) | The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB) | `number` | `262144` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,14 +19,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.30 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -41,6 +41,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_sqs_queue_policy.users_unencrypted_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_kms_key" "this" {}
 
 module "users_unencrypted" {
@@ -37,7 +39,7 @@ resource "aws_sqs_queue_policy" "users_unencrypted_policy" {
       {
         "Effect": "Allow",
         "Principal": {
-          "AWS": "arn:aws:iam::myaccount:root"
+          "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         },
         "Action": [
           "SQS:SendMessage",

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 2.30"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.63"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,8 @@ resource "aws_sqs_queue" "this" {
   redrive_policy              = var.redrive_policy
   fifo_queue                  = var.fifo_queue
   content_based_deduplication = var.content_based_deduplication
+  deduplication_scope         = var.deduplication_scope
+  fifo_throughput_limit       = var.fifo_throughput_limit
 
   kms_master_key_id                 = var.kms_master_key_id
   kms_data_key_reuse_period_seconds = var.kms_data_key_reuse_period_seconds

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,18 @@ variable "kms_data_key_reuse_period_seconds" {
   default     = 300
 }
 
+variable "deduplication_scope" {
+  description = "Specifies whether message deduplication occurs at the message group or queue level"
+  type        = string
+  default     = null
+}
+
+variable "fifo_throughput_limit" {
+  description = "Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "A mapping of tags to assign to all resources"
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 2.30"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.63"
+    }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Add more variables for fifo queues with default values as per documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue
2. Allow example to be applied without changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/terraform-aws-modules/terraform-aws-sqs/issues/31

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->