### PR TITLE
fix: Add conditional null for sqs_managed_sse_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_sqs_queue" "this" {
   deduplication_scope         = var.deduplication_scope
   fifo_throughput_limit       = var.fifo_throughput_limit
 
-  sqs_managed_sse_enabled           = var.sqs_managed_sse_enabled
+  sqs_managed_sse_enabled           = var.sqs_managed_sse_enabled ? var.sqs_managed_sse_enabled : null
   kms_master_key_id                 = var.sqs_managed_sse_enabled ? null : var.kms_master_key_id
   kms_data_key_reuse_period_seconds = var.kms_data_key_reuse_period_seconds
 


### PR DESCRIPTION
## Description
Conditionally set the variable `sqs_managed_sse_enabled` to `null` as setting this variable to anything else conflicts with the `kms_master_key_id`.

## Motivation and Context
Closes #40 

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) - N.A.
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects - Ran the full suite
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
