### PR TITLE
fix: Adjust conditionals for encryption settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,8 @@ resource "aws_sqs_queue" "this" {
   deduplication_scope         = var.deduplication_scope
   fifo_throughput_limit       = var.fifo_throughput_limit
 
-  sqs_managed_sse_enabled           = var.sqs_managed_sse_enabled ? var.sqs_managed_sse_enabled : null
-  kms_master_key_id                 = var.sqs_managed_sse_enabled ? null : var.kms_master_key_id
+  sqs_managed_sse_enabled           = var.kms_master_key_id == null ? var.sqs_managed_sse_enabled : null
+  kms_master_key_id                 = var.kms_master_key_id != null ? var.kms_master_key_id : null
   kms_data_key_reuse_period_seconds = var.kms_data_key_reuse_period_seconds
 
   tags = var.tags


### PR DESCRIPTION
## Description
SQS queues are now [encrypted by default](https://aws.amazon.com/blogs/compute/announcing-server-side-encryption-with-amazon-simple-queue-service-managed-encryption-keys-sse-sqs-by-default/) with SSE SQS. 

With the existing conditional, it sets `sms_managed_sse_enabled` if set to `true` otherwise defaults to `null` which is default encrypted. There's no way to now set `false` to disable encryption. 

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-sqs/issues/44

## Breaking Changes
Anyone who has used this module to create new SQS queues since AWS enabled encryption by default may show their queues set to disable encryption. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
