### PR TITLE
fix: Correct `.fifo` postfix and KMS key ID usage on dead letter queue

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -35,6 +35,13 @@ module "fifo_sqs" {
   name       = local.name
   fifo_queue = true
 
+  # Dead letter queue
+  create_dlq = true
+  redrive_policy = {
+    # default is 5 for this module
+    maxReceiveCount = 10
+  }
+
   tags = local.tags
 }
 
@@ -55,6 +62,13 @@ module "cmk_encrypted_sqs" {
 
   kms_master_key_id                 = aws_kms_key.this.id
   kms_data_key_reuse_period_seconds = 3600
+
+  # Dead letter queue
+  create_dlq = true
+  redrive_policy = {
+    # default is 5 for this module
+    maxReceiveCount = 10
+  }
 
   tags = local.tags
 }


### PR DESCRIPTION
## Description
- Correct the use of the `.fifo` postfix regardless of whether the user specifies it or not on dead letter queue
- Ensure that the KMS key ID is used on the dead letter queue when one is provided

## Motivation and Context
- Resolves #48
- Resolves #50

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
