### PR TITLE
Disabled adding .fifo suffix to DLQ name if use_name_prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_sqs_queue_redrive_policy" "dlq" {
 locals {
   stripped_dlq_name = try(trimsuffix(var.dlq_name, ".fifo"), "")
   inter_dlq_name    = try(coalesce(local.stripped_dlq_name, "${local.name}-dlq"), "")
-  dlq_name          = var.fifo_queue ? "${local.inter_dlq_name}.fifo" : local.inter_dlq_name
+  dlq_name          = var.fifo_queue && !var.use_name_prefix ? "${local.inter_dlq_name}.fifo" : local.inter_dlq_name
 
   dlq_kms_master_key_id       = try(coalesce(var.dlq_kms_master_key_id, var.kms_master_key_id), null)
   dlq_sqs_managed_sse_enabled = coalesce(var.dlq_sqs_managed_sse_enabled, var.sqs_managed_sse_enabled)


### PR DESCRIPTION
## Description
Disabled adding `.fifo` suffix to dlq name if `use_name_prefix = true`

## Motivation and Context
Without this, I receive `Error: invalid queue name`, because dlq name has .fifo in middle of the name as well as in the suffix.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
