### PR TITLE
feat: Add option to disable creation of redrive policy for the dead letter queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create SQS queue | `bool` | `true` | no |
 | <a name="input_create_dlq"></a> [create\_dlq](#input\_create\_dlq) | Determines whether to create SQS dead letter queue | `bool` | `false` | no |
 | <a name="input_create_dlq_queue_policy"></a> [create\_dlq\_queue\_policy](#input\_create\_dlq\_queue\_policy) | Whether to create SQS queue policy | `bool` | `false` | no |
+| <a name="input_create_dlq_redrive_allow_policy"></a> [create\_dlq\_redrive\_allow\_policy](#input\_create\_dlq\_redrive\_allow\_policy) | Determines whether to create a redrive allow policy for the dead letter queue. | `bool` | `true` | no |
 | <a name="input_create_queue_policy"></a> [create\_queue\_policy](#input\_create\_queue\_policy) | Whether to create SQS queue policy | `bool` | `false` | no |
 | <a name="input_deduplication_scope"></a> [deduplication\_scope](#input\_deduplication\_scope) | Specifies whether message deduplication occurs at the message group or queue level | `string` | `null` | no |
 | <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds) | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes) | `number` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   name   = "ex-${basename(path.cwd)}"
-  region = "eu-west-1"
+  region = "us-east-1"
 
   tags = {
     Name       = local.name
@@ -137,6 +137,7 @@ module "sqs_with_dlq" {
     # default is 5 for this module
     maxReceiveCount = 10
   }
+  create_dlq_redrive_allow_policy = false
 
   # Dead letter queue policy
   # Not required - just showing example

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   name   = "ex-${basename(path.cwd)}"
-  region = "us-east-1"
+  region = "eu-west-1"
 
   tags = {
     Name       = local.name

--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,7 @@ resource "aws_sqs_queue_redrive_allow_policy" "this" {
 }
 
 resource "aws_sqs_queue_redrive_allow_policy" "dlq" {
-  count = var.create && var.create_dlq ? 1 : 0
+  count = var.create && var.create_dlq && var.create_dlq_redrive_allow_policy ? 1 : 0
 
   queue_url = aws_sqs_queue.dlq[0].url
   redrive_allow_policy = jsonencode(merge(

--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,12 @@ variable "dlq_receive_wait_time_seconds" {
   default     = null
 }
 
+variable "create_dlq_redrive_allow_policy" {
+  description = "Determines whether to create a redrive allow policy for the dead letter queue."
+  type        = bool
+  default     = true
+}
+
 variable "dlq_redrive_allow_policy" {
   description = "The JSON policy to set up the Dead Letter Queue redrive permission, see AWS docs."
   type        = any

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -34,6 +34,7 @@ module "wrapper" {
   dlq_message_retention_seconds         = try(each.value.dlq_message_retention_seconds, var.defaults.dlq_message_retention_seconds, null)
   dlq_name                              = try(each.value.dlq_name, var.defaults.dlq_name, null)
   dlq_receive_wait_time_seconds         = try(each.value.dlq_receive_wait_time_seconds, var.defaults.dlq_receive_wait_time_seconds, null)
+  create_dlq_redrive_allow_policy       = try(each.value.create_dlq_redrive_allow_policy, var.defaults.create_dlq_redrive_allow_policy, true)
   dlq_redrive_allow_policy              = try(each.value.dlq_redrive_allow_policy, var.defaults.dlq_redrive_allow_policy, {})
   dlq_sqs_managed_sse_enabled           = try(each.value.dlq_sqs_managed_sse_enabled, var.defaults.dlq_sqs_managed_sse_enabled, true)
   dlq_visibility_timeout_seconds        = try(each.value.dlq_visibility_timeout_seconds, var.defaults.dlq_visibility_timeout_seconds, null)


### PR DESCRIPTION
…ueue (#59)

## Description
<!--- Describe your changes in detail -->
Created a variable `create_dlq_redrive_allow_policy` and added it's value to the conditional count statement in the `resource "aws_sqs_queue_redrive_allow_policy" "dlq"`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some AWS regions do not support redrive allow policies on dead letter queues (DLQ). Thus, when deploying a stack that includes a DLQ in one of these regions, the stack will fail because Terraform attempts to create resource "aws_sqs_queue_redrive_allow_policy" "dlq" due to var.create_dlq = true.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/terraform-aws-modules/terraform-aws-sqs/issues/59

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
I deployed a stack from `examples/complete` and confirmed the presence of a redrive allow policy in the dlq resource. Then I set `create_dlq_redrive_allow_policy = false` in the template, redployed, and confirmed the change in both the terraform state and resource itself. 
- [x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
