### PR TITLE
fix: Enforce Number format on redrive policy

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_default_sqs"></a> [default\_sqs](#module\_default\_sqs) | ../../ | n/a |
 | <a name="module_disabled_sqs"></a> [disabled\_sqs](#module\_disabled\_sqs) | ../../ | n/a |
 | <a name="module_fifo_sqs"></a> [fifo\_sqs](#module\_fifo\_sqs) | ../../ | n/a |
+| <a name="module_sqs_string_max_receive_count"></a> [sqs\_string\_max\_receive\_count](#module\_sqs\_string\_max\_receive\_count) | ../../ | n/a |
 | <a name="module_sqs_with_dlq"></a> [sqs\_with\_dlq](#module\_sqs\_with\_dlq) | ../../ | n/a |
 | <a name="module_sse_encrypted_dlq_sqs"></a> [sse\_encrypted\_dlq\_sqs](#module\_sse\_encrypted\_dlq\_sqs) | ../../ | n/a |
 | <a name="module_sse_encrypted_sqs"></a> [sse\_encrypted\_sqs](#module\_sse\_encrypted\_sqs) | ../../ | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -45,6 +45,17 @@ module "fifo_sqs" {
   tags = local.tags
 }
 
+module "sqs_string_max_receive_count" {
+  source = "../../"
+
+  name = "${local.name}-default"
+
+  redrive_policy = {
+    maxReceiveCount = "10"
+  }
+  tags = local.tags
+}
+
 module "unencrypted_sqs" {
   source = "../../"
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ data "aws_caller_identity" "current" {}
 locals {
   name = try(trimsuffix(var.name, ".fifo"), "")
   redrive_policy = merge(var.redrive_policy, {
-    maxReceiveCount     = tonumber(var.redrive_policy.maxReceiveCount)
+    maxReceiveCount = tonumber(var.redrive_policy.maxReceiveCount)
   })
 }
 


### PR DESCRIPTION
## Description
The input for redrive policy specifies that the input for `maxReceiveCount` needs to be a number, however because the variable `redrive_policy` is `any` we run into issues where terraform is changing it to be a string, see [terraform any](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#any-with-collection-types). This is problematic because AWS API requires a number. We see the symptom of this where terraform apply results in

```console
│ Error: waiting for SQS Queue (https://...) attribute (RedrivePolicy) create: timeout while waiting for state to become 'equal' (last state: 'notequal', timeout: 2m0s)
│ 
│   with module.sqs.aws_sqs_queue_redrive_policy.dlq[0],
│   on .terraform/modules/sqs/main.tf line 104, in resource "aws_sqs_queue_redrive_policy" "dlq":
│  104: resource "aws_sqs_queue_redrive_policy" "dlq" {
│ 
```

## Motivation and Context
We need one of two changes. 
1. The first is to use `merge` and `tonumber` to enforce a number format when json encoding the object. This ensures that whatever the user of this module passes will be a number (or it will error stating that it needs a number - which is also helpful information).
2. The other option would be to change the variable type from any to an object - such as:
```hcl
variable "redrive_policy" {
  description = "The JSON policy to set up the Dead Letter Queue, see AWS docs. Note: when specifying maxReceiveCount, you must specify it as an integer (5), and not a string (\"5\")"
  type        = object({
    deadLetterTargetArn = optional(string)
    maxReceiveCount      = number
  })
  default     = {}
}
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
