### PR TITLE
fix: Update AWS provider version constraint to ~> 5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.36"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This pull request updates the version requirement for the AWS provider in the `versions.tf` file to ensure compatibility with the latest features and improvements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* [`versions.tf`](diffhunk://#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927L7-R7): Updated the `aws` provider version from `>= 4.36` to `~> 5.0` to ensure compatibility with newer features and improvements.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
