### PR TITLE
fix: Correct queue_static_arn output for FIFO queues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,8 @@ locals {
 ################################################################################
 
 locals {
-  name = try(trimsuffix(var.name, ".fifo"), "")
+  name        = try(trimsuffix(var.name, ".fifo"), "")
+  static_name = var.fifo_queue ? var.name : local.name
 }
 
 resource "aws_sqs_queue" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "queue_arn" {
 
 output "queue_arn_static" {
   description = "The ARN of the SQS queue. Use this to avoid cycle errors between resources (e.g., Step Functions)"
-  value       = var.create && !var.use_name_prefix ? "arn:${local.partition}:sqs:${local.region}:${local.account_id}:${local.name}" : ""
+  value       = var.create && !var.use_name_prefix ? "arn:${local.partition}:sqs:${local.region}:${local.account_id}:${local.static_name}" : ""
 }
 
 output "queue_url" {


### PR DESCRIPTION
## Description
* Support for `queue_static_arn` output when the queue is FIFO

## Motivation and Context
* When using the `queue_static_arn` and a FIFO queue, the `.fifo` is stripped causing the subscription ARN to be incorrect

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request